### PR TITLE
Adds nip60.signSecret() support

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -198,6 +198,12 @@
         if (!connecting && !connected) connectOrOpen()
         return (await bunker).nip44Decrypt(pubkey, ciphertext)
       }
+    },
+    nip60: {
+      async signSecret(proof_secret: string): Promise<string> {
+        if (!connecting && !connected) connectOrOpen()
+        return (await bunker).nip60SignSecret(proof_secret)
+      }
     }
   }
 


### PR DESCRIPTION
Might be a smidge too early, as bunkers don't generally know about this yet, but putting it here in anticipation.
See: https://github.com/nostr-protocol/nips/pull/1890